### PR TITLE
cug test plots

### DIFF
--- a/server.R
+++ b/server.R
@@ -2196,11 +2196,29 @@ output$cugtest <- renderPlot({
                    directed = nw()$gal$directed, loops = nw()$gal$loops)
   
   brghist <- hist(brgvals, plot = FALSE)
-  cughist <- hist(cugvals, breaks = brghist$breaks, plot = FALSE)
+  
+  getbreaks <- function(x){  
+    breaks <- brghist$breaks
+    r <- range(brghist$breaks)
+    int <- breaks[2] - breaks[1]
+    if(min(x) < r[1]){
+      toadd <- ceiling((r[1] - min(x))/int)
+      front <- c((r[1]-toadd*int):(r[1]-int))
+      breaks <- c(front, breaks)
+    }
+    if (max(x) > r[2]) {
+      toadd <- ceiling((max(x)-r[2])/int)
+      back <- c((r[2]+int):(r[2]+toadd*int))
+      breaks <- c(breaks, back)
+    }
+    return(breaks)
+  }
+  
+  cughist <- hist(cugvals, breaks = getbreaks, plot = FALSE)
   hist(cugvals, col = tgray, border = CUGcol, ylab = NULL, main = NULL, 
        xlab= NULL, xlim = range(brgvals, cugvals, obsval), 
        ylim = c(0, max(brghist$counts, cughist$counts)), 
-       breaks = brghist$breaks)
+       breaks = getbreaks)
   hist(brgvals, col = "gray60", density = 15, 
        angle = -45, border = BRGcol, ylab = NULL, main = NULL, xlab= NULL, 
        ylim = c(0, max(brghist$counts, cughist$counts)), 

--- a/server.R
+++ b/server.R
@@ -261,8 +261,8 @@ nodes <- reactive({
   nwinit()$gal$n
 })
 
-#number of edges in nw
-nedges <- reactive({
+#number of edges in initial nw
+nedgesinit <- reactive({
   if(!is.network(nwinit())) return()
   network.edgecount(nwinit())
 })
@@ -295,7 +295,7 @@ observe({
   evdf <- list()
   if (is.network(nwinit())){
     n <- nodes()
-    e <- nedges()
+    e <- nedgesinit()
     for (i in 1:n){
       vdf <- rbind(vdf,i)
     }
@@ -668,6 +668,7 @@ legendfill <- reactive({
 #simulated graphs for cug tests
 observeEvent(c(nw(), input$ncugsims),{
   if(!is.null(nw())){
+    s <- network.edgecount(nw())
     if (is.directed(nw())){
       mode <- "digraph"
     } else {
@@ -676,7 +677,7 @@ observeEvent(c(nw(), input$ncugsims),{
     
     brgsims <- rgraph(n = nodes(), m = input$ncugsims, tprob = gden(nw()), mode = mode, 
                       diag = nw()$gal$loops)
-    cugsims <- rgnm(n = input$ncugsims, nv = nodes(), m = nedges(), mode = mode,
+    cugsims <- rgnm(n = input$ncugsims, nv = nodes(), m = s, mode = mode,
                     diag = nw()$gal$loops)
     
     values$cugsims <- list(brgsims, cugsims)
@@ -1416,11 +1417,12 @@ uniformsamples <- reactive({
   if(!is.network(nw())){
     return()
   }
+  s <- network.edgecount(nw())
   if(is.directed(nw())){
-    samples <- rgnm(n=50, nv=nodes(), m=nedges(), mode='digraph',
+    samples <- rgnm(n=50, nv=nodes(), m=s, mode='digraph',
                     diag=has.loops(nw()))
   } else {
-    samples <- rgnm(n=50, nv=nodes(), m=nedges(), mode='graph',
+    samples <- rgnm(n=50, nv=nodes(), m=s, mode='graph',
                     diag=has.loops(nw()))
   }
   samples


### PR DESCRIPTION
fix two small errors: ensure count of edges is correct, ensure enough breakpoints in the histogram when cugvals has a wider range than brgvals