### PR TITLE
remove superfluous option causing error

### DIFF
--- a/inst/shiny/statnetWeb/ui.R
+++ b/inst/shiny/statnetWeb/ui.R
@@ -1183,7 +1183,7 @@ tabPanel(title='Simulations', value='tab7',
                            fluidRow(
                              column(3, class = "shiftright",
                                     inlineSelectInput('simcontroltype',label=NULL,
-                                                      choices=c("MCMC","Parallel"),
+                                                      choices=c("MCMC"),
                                                       style="margin:10px 0px;")),
                              column(7,
                                     checkboxInput('simcontroldefault','Use default options', value=TRUE))


### PR DESCRIPTION
This fixes the startup warnings/errors for me.

I removed the `"Parallel"` option from the control drop down menu since it doesn't appear to have been implemented anyway, cf.

https://github.com/statnet/statnetWeb/blob/b1be7c007f53fe7b6f738164064a413da07aec61/inst/shiny/statnetWeb/ui.R#L1218-L1219

The argument of length > 1 was `c("MCMC","Parallel")` here

https://github.com/statnet/statnetWeb/blob/b1be7c007f53fe7b6f738164064a413da07aec61/inst/shiny/statnetWeb/ui.R#L1186

which is now just `c("MCMC")`.